### PR TITLE
Create a "save sharing" command.

### DIFF
--- a/commands/8/savesharing.js
+++ b/commands/8/savesharing.js
@@ -1,0 +1,20 @@
+/* eslint-disable max-len */
+"use strict";
+
+const { ApplicationCommand } = require("../../classes/ApplicationCommand/ApplicationCommand");
+
+module.exports = {
+  command: new ApplicationCommand({
+
+    name: "savesharing",
+    description: "Provides a brief explanation on sharing saves.",
+    check: true,
+    sent: [`Due to the size of Antimatter Dimensions saves, you can not share them directly on Discord. \nInstead, you need to upload them to a site such as <https://paste.ee/>. Pastebin will NOT work for this. \n\nTo do this, follow these steps: 
+    1.  Export your save from the "Settings" tab in-game. 
+    2.  Open up <https://paste.ee/> in your browser of choice. 
+    3.  Paste your save data in the big box in the site. Save data begins with "AntimatterDimensionsSavefileFormat" and Ends with "EndOfSaveFile". 
+    4.  Click "Submit" at the bottom of the page. You will be taken to a new page with your save data. 
+    5.  Copy the URL to the page. It should look like this: <https://paste.ee/p/xxxxx>
+    6.  Paste that link in the Discord. Kajfik or another helper can then look at your save data.`]
+  })
+};

--- a/commands/8/savesharing.js
+++ b/commands/8/savesharing.js
@@ -10,11 +10,11 @@ module.exports = {
     description: "Provides a brief explanation on sharing saves.",
     check: true,
     sent: [`Due to the size of Antimatter Dimensions saves, you can not share them directly on Discord. \nInstead, you need to upload them to a site such as <https://paste.ee/>. Pastebin will NOT work for this. \n\nTo do this, follow these steps: 
-    1.  Export your save from the "Settings" tab in-game. 
+    1.  Export your save from the "Options" tab in-game. You should get a pop-up saying your save was copied to your clipboard.
     2.  Open up <https://paste.ee/> in your browser of choice. 
-    3.  Paste your save data in the big box in the site. Save data begins with "AntimatterDimensionsSavefileFormat" and Ends with "EndOfSaveFile". 
+    3.  Paste your save data in the big box in the site. Save data begins with "AntimatterDimensionsSavefileFormat" or "AntimatterDimensionsAndroidSaveFormat" and ends with "EndOfSaveFile". 
     4.  Click "Submit" at the bottom of the page. You will be taken to a new page with your save data. 
     5.  Copy the URL to the page. It should look like this: <https://paste.ee/p/xxxxx>
-    6.  Paste that link in the Discord. Kajfik or another helper can then look at your save data.`]
+    6.  Paste that link in the Discord. A helper can then copy and look at your save data.`]
   })
 };

--- a/utils/commands.js
+++ b/utils/commands.js
@@ -593,6 +593,10 @@ module.exports = {
       name: "savebank",
       description: "Provides a link to Buck's save bank."
     },
+    {
+      name: "savesharing",
+      description: "Provides a brief explanation on sharing saves."
+    },
     { name: "secondsplit", description: "describes second split paths" },
     {
       name: "setcrunchauto",


### PR DESCRIPTION
Create a "save sharing" command for the purposes of explaining to new users how to share their save with helpers. Hopefully this should eliminate most problems with it.

I have not checked what this looks like when the bot says it. An indent or two can be added where needed if it comes out wrong. 