### PR TITLE
Added option mobile to remove codeblocks for copying on mobile

### DIFF
--- a/src/classes/Tree.ts
+++ b/src/classes/Tree.ts
@@ -6,10 +6,12 @@ export class Tree {
   theorems: number;
   path: string;
   trees: Trees[];
-  constructor(theorems: number, path?: string) {
+  mobile: boolean;
+  constructor(theorems: number, path?: string, mobile?:boolean) {
     this.theorems = Math.max(theorems, 0);
     this.path = path === undefined ? "active" : path;
     this.trees = trees(this.path);
+    this.mobile = mobile === undefined ? false : mobile;
   }
 
   get realPath(): string {
@@ -25,6 +27,11 @@ export class Tree {
     for (const tree of this.trees) {
       if (this.theorems >= tree.requirement) {
         const affordableStudies = getAffordableStudiesFromStudyList(tree.ts, this.theorems);
+        if (this.mobile) {
+          return `${tree.desc === undefined
+            ? ""
+            : `${tree.desc} `}${affordableStudies.join(",")}|0`;
+        }
         return `${tree.desc === undefined
           ? ""
           : `${tree.desc} `}\`${affordableStudies.join(",")}|0\``;

--- a/src/commands/3/ts.ts
+++ b/src/commands/3/ts.ts
@@ -33,6 +33,12 @@ export const ts: Command = {
       description: "Will show current ECs for that TT amount; x >= 130 where 130 is TT",
       type: ApplicationCommandOptionType.Boolean,
       required: false
+    },
+    {
+      name: "mobile",
+      description: "Removes codeblock so copying on mobile is simpler",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
     }
   ],
   run: async(interaction: CommandInteraction) => {
@@ -41,7 +47,8 @@ export const ts: Command = {
     const theorems: number = interaction.options.getInteger("theorems") as number;
     const path: string = interaction.options.getString("path") as string;
     const showECs: boolean = interaction.options.getBoolean("showecs") as boolean;
-    const tree = new Tree(theorems, path).generateTree();
+    let mobile: boolean = interaction.options.getBoolean("mobile") as boolean;
+    const tree = new Tree(theorems, path, mobile).generateTree();
     const ecs = ecsAtTTAmount(theorems);
     const next = typeof ecs === "string" ? "" : `(Next: ${makeEnumeration<string>(ecs.nextECs, ", ", "", "and")} at ${ecs.nextEC.tt} TT)`;
     const ecString: string = showECs && theorems >= 130 ? `EC completions for ${theorems} TT: ${typeof ecs === "string" ? ecs : ecs.completions} ${next}` : "";


### PR DESCRIPTION
When using the TS command on mobile it's a hassle to remove the backticks so this option would maybe help with that?